### PR TITLE
Feature/string types with default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <k3po.version>3.0.0-alpha-104</k3po.version>
     <reaktor.version>0.130</reaktor.version>
 
-    <nukleus.plugin.version>0.50</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
     <nukleus.spec.version>0.47</nukleus.spec.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <k3po.version>3.0.0-alpha-104</k3po.version>
     <reaktor.version>0.130</reaktor.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.53</nukleus.plugin.version>
     <nukleus.spec.version>0.47</nukleus.spec.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
+++ b/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
@@ -35,10 +35,12 @@ public final class MqttFunctions
     @Function
     public static byte[] userProperty(String key, String value)
     {
-        final MqttUserPropertyFW mqttUserProperty = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
-                                                                                    .key(key)
-                                                                                    .value(value)
-                                                                                    .build();
+        final MqttUserPropertyFW mqttUserProperty =
+            new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
+                                            .key(key)
+                                            .value(value)
+                                            .build();
+
         final byte[] array = new byte[mqttUserProperty.sizeof()];
         mqttUserProperty.buffer().getBytes(mqttUserProperty.offset(), array);
 

--- a/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
+++ b/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
@@ -24,6 +24,7 @@ import org.kaazing.k3po.lang.el.spi.FunctionMapperSpi;
 import org.reaktivity.specification.mqtt.internal.types.MqttCapabilities;
 import org.reaktivity.specification.mqtt.internal.types.MqttPayloadFormat;
 import org.reaktivity.specification.mqtt.internal.types.MqttPayloadFormatFW;
+import org.reaktivity.specification.mqtt.internal.types.MqttUserPropertyFW;
 import org.reaktivity.specification.mqtt.internal.types.control.MqttRouteExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttAbortExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttBeginExFW;
@@ -31,6 +32,19 @@ import org.reaktivity.specification.mqtt.internal.types.stream.MqttDataExFW;
 
 public final class MqttFunctions
 {
+    @Function
+    public static byte[] userProperty(String key, String value)
+    {
+        final MqttUserPropertyFW mqttUserProperty = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
+                                                                                    .key(key)
+                                                                                    .value(value)
+                                                                                    .build();
+        final byte[] array = new byte[mqttUserProperty.sizeof()];
+        mqttUserProperty.buffer().getBytes(mqttUserProperty.offset(), array);
+
+        return array;
+    }
+
     @Function
     public static byte[] payloadFormat(String format)
     {

--- a/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
+++ b/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
@@ -204,8 +204,6 @@ public final class MqttFunctions
         public MqttDataExBuilder expiryInterval(
             int msgExp)
         {
-            ensureTopicSet();
-
             dataExRW.expiryInterval(msgExp);
             return this;
         }
@@ -221,8 +219,6 @@ public final class MqttFunctions
         public MqttDataExBuilder format(
             String format)
         {
-            ensureContentTypeSet();
-
             dataExRW.format(p -> p.set(MqttPayloadFormat.valueOf(format)));
             return this;
         }
@@ -230,8 +226,6 @@ public final class MqttFunctions
         public MqttDataExBuilder responseTopic(
             String topic)
         {
-            ensureContentTypeSet();
-
             responseTopicSet = true;
             dataExRW.responseTopic(topic);
             return this;
@@ -240,8 +234,6 @@ public final class MqttFunctions
         public MqttDataExBuilder correlation(
             String correlation)
         {
-            ensureResponseTopicSet();
-
             dataExRW.correlation(c -> c.bytes(b -> b.set(correlation.getBytes(UTF_8))));
             return this;
         }
@@ -249,8 +241,6 @@ public final class MqttFunctions
         public MqttDataExBuilder correlationBytes(
             byte[] correlation)
         {
-            ensureResponseTopicSet();
-
             dataExRW.correlation(c -> c.bytes(b -> b.set(correlation)));
             return this;
         }
@@ -259,9 +249,6 @@ public final class MqttFunctions
             String name,
             String value)
         {
-            ensureTopicSet();
-            ensureResponseTopicSet();
-
             dataExRW.propertiesItem(p -> p.key(name)
                                           .value(value));
             return this;
@@ -269,38 +256,10 @@ public final class MqttFunctions
 
         public byte[] build()
         {
-            ensureTopicSet();
-            ensureContentTypeSet();
-            ensureResponseTopicSet();
-
             final MqttDataExFW dataEx = dataExRW.build();
             final byte[] array = new byte[dataEx.sizeof()];
             dataEx.buffer().getBytes(dataEx.offset(), array);
             return array;
-        }
-
-        private void ensureTopicSet()
-        {
-            if (!topicSet)
-            {
-                topic(null);
-            }
-        }
-
-        private void ensureContentTypeSet()
-        {
-            if (!contentTypeSet)
-            {
-                contentType(null);
-            }
-        }
-
-        private void ensureResponseTopicSet()
-        {
-            if (!responseTopicSet)
-            {
-                responseTopic(null);
-            }
         }
     }
 

--- a/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
+++ b/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
@@ -259,6 +259,7 @@ public final class MqttFunctions
             String name,
             String value)
         {
+            ensureTopicSet();
             ensureResponseTopicSet();
 
             dataExRW.propertiesItem(p -> p.key(name)

--- a/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
+++ b/src/main/java/org/reaktivity/specification/mqtt/internal/MqttFunctions.java
@@ -24,7 +24,6 @@ import org.kaazing.k3po.lang.el.spi.FunctionMapperSpi;
 import org.reaktivity.specification.mqtt.internal.types.MqttCapabilities;
 import org.reaktivity.specification.mqtt.internal.types.MqttPayloadFormat;
 import org.reaktivity.specification.mqtt.internal.types.MqttPayloadFormatFW;
-import org.reaktivity.specification.mqtt.internal.types.MqttUserPropertyFW;
 import org.reaktivity.specification.mqtt.internal.types.control.MqttRouteExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttAbortExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttBeginExFW;
@@ -32,21 +31,6 @@ import org.reaktivity.specification.mqtt.internal.types.stream.MqttDataExFW;
 
 public final class MqttFunctions
 {
-    @Function
-    public static byte[] userProperty(String key, String value)
-    {
-        final MqttUserPropertyFW mqttUserProperty =
-            new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
-                                            .key(key)
-                                            .value(value)
-                                            .build();
-
-        final byte[] array = new byte[mqttUserProperty.sizeof()];
-        mqttUserProperty.buffer().getBytes(mqttUserProperty.offset(), array);
-
-        return array;
-    }
-
     @Function
     public static byte[] payloadFormat(String format)
     {

--- a/src/main/resources/META-INF/reaktivity/mqtt.idl
+++ b/src/main/resources/META-INF/reaktivity/mqtt.idl
@@ -63,11 +63,11 @@ scope mqtt
         struct MqttDataEx extends core::stream::Extension
         {
             int32 deferred = 0;             // INIT only (TODO: move to DATA frame)
-            string16 topic;
+            string16 topic = null;
             int32 expiryInterval = -1;
-            string8 contentType;
+            string8 contentType = null;
             MqttPayloadFormat format = BINARY;
-            string8 responseTopic;
+            string8 responseTopic = null;
             MqttBinary correlation;
             MqttUserProperty[] properties;
         }

--- a/src/main/scripts/org/reaktivity/specification/mqtt/disconnect.after.keep.alive.timeout/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/disconnect.after.keep.alive.timeout/client.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_SERVER
+        "nukleus://streams/mqtt#0"
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+connected
+
+write [0x10 0x13]             # CONNECT header
+      [0x00 0x04] "MQTT"      # protocol name
+      [0x05]                  # protocol version
+      [0x02]                  # connect flags = clean start
+      [0x00 0x0a]             # keep alive = 10s
+      [0x00]                  # properties = none
+      [0x00 0x06] "client"    # clientId
+
+read  [0x20 0x03]             # CONNACK header
+      [0x00]                  # connect flags = none
+      [0x00]                  # reason code
+      [0x00]                  # properties = none
+
+read  [0xe0 0x02]             # disconnect header
+      [0x8d]                  # DISCONNECT = keep alive timeout
+      [0x00]                  # properties = none

--- a/src/main/scripts/org/reaktivity/specification/mqtt/disconnect.after.keep.alive.timeout/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/disconnect.after.keep.alive.timeout/server.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+accepted
+connected
+
+read  [0x10 0x13]             # CONNECT header
+      [0x00 0x04] "MQTT"      # protocol name
+      [0x05]                  # protocol version
+      [0x02]                  # connect flags = clean start
+      [0x00 0x0a]             # keep alive = 10s
+      [0x00]                  # properties = none
+      [0x00 0x06] "client"    # clientId
+
+write [0x20 0x03]             # CONNACK header
+      [0x00]                  # connect flags = none
+      [0x00]                  # reason code
+      [0x00]                  # properties = none    
+
+write [0xe0 0x02]             # disconnect header
+      [0x8d]                  # DISCONNECT = keep alive timeout
+      [0x00]                  # properties = none

--- a/src/main/scripts/org/reaktivity/specification/mqtt/keep.alive.with.pingreq/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/keep.alive.with.pingreq/client.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_SERVER
+        "nukleus://streams/mqtt#0"
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+connected
+
+write  [0x10 0x13]                   # CONNECT header
+       [0x00 0x04] "MQTT"            # protocol name
+       [0x05]                        # protocol version
+       [0x02]                        # connect flags = clean start
+       [0x00 0x0a]                   # keep alive = 10s
+       [0x00]                        # properties = none
+       [0x00 0x06] "client"          # clientId
+
+read   [0x20 0x03]                   # CONNACK header
+       [0x00]                        # connect flags = none
+       [0x00]                        # reason code
+       [0x00]                        # properties = none
+
+write  [0xc0 0x00]                   # PINGREQ header
+
+read   [0xd0 0x00]                   # PINGRESP header
+
+write  [0x82 0x12]                   # SUBSCRIBE header
+       [0x00 0x01]                   # packetId = 1
+       [0x02]                        # properties
+       [0x0b 0x01]                   # subscriptionId = 1
+       [0x00 0x0a] "sensor/one"      # topic filter
+       [0x00]                        # subscription opts = QoS 0
+
+read   [0x90 0x04]                   # SUBACK header
+       [0x00 0x01]                   # packetId = 1
+       [0x00]                        # properties = none
+       [0x00]                        # reason code

--- a/src/main/scripts/org/reaktivity/specification/mqtt/keep.alive.with.pingreq/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/keep.alive.with.pingreq/server.rpt
@@ -1,0 +1,53 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+accepted
+connected
+
+read   [0x10 0x13]                   # CONNECT header
+       [0x00 0x04] "MQTT"            # protocol name
+       [0x05]                        # protocol version
+       [0x02]                        # connect flags = clean start
+       [0x00 0x0a]                   # keep alive = 10s
+       [0x00]                        # properties = none
+       [0x00 0x06] "client"          # clientId
+
+write  [0x20 0x03]                   # CONNACK header
+       [0x00]                        # connect flags = none
+       [0x00]                        # reason code
+       [0x00]                        # properties = none
+
+read   [0xc0 0x00]                   # PINGREQ header
+
+write  [0xd0 0x00]                   # PINGRESP header
+
+read   [0x82 0x12]                   # SUBSCRIBE header
+       [0x00 0x01]                   # packetId = 1
+       [0x02]                        # properties
+       [0x0b 0x01]                   # subscriptionId = 1
+       [0x00 0x0a] "sensor/one"      # topic filter
+       [0x00]                        # subscription opts = QoS 0
+
+write  [0x90 0x04]                   # SUBACK header
+       [0x00 0x01]                   # packetId = 1
+       [0x00]                        # properties = none
+       [0x00]                        # reason code

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kaazing.k3po.lang.internal.el.ExpressionContext;
 import org.reaktivity.specification.mqtt.internal.types.MqttCapabilities;
+import org.reaktivity.specification.mqtt.internal.types.MqttUserPropertyFW;
 import org.reaktivity.specification.mqtt.internal.types.control.MqttRouteExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttAbortExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttBeginExFW;
@@ -55,6 +56,17 @@ public class MqttFunctionsTest
     {
         MqttFunctions.Mapper mapper = new MqttFunctions.Mapper();
         assertEquals("mqtt", mapper.getPrefixName());
+    }
+
+    @Test
+    public void shouldEncodeUserProperty()
+    {
+        final byte[] bytes = MqttFunctions.userProperty("name", "value");
+
+        DirectBuffer buffer = new UnsafeBuffer(bytes);
+        MqttUserPropertyFW userProperty = new MqttUserPropertyFW().wrap(buffer, 0, buffer.capacity());
+
+        assertArrayEquals(userProperty.buffer().byteArray(), bytes);
     }
 
     @Test

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -66,7 +66,7 @@ public class MqttFunctionsTest
         DirectBuffer buffer = new UnsafeBuffer(bytes);
         MqttUserPropertyFW userProperty = new MqttUserPropertyFW().wrap(buffer, 0, buffer.capacity());
 
-        MqttUserPropertyFW expected = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]),0, 1024)
+        MqttUserPropertyFW expected = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
                                                                       .key("name")
                                                                       .value("value")
                                                                       .build();

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kaazing.k3po.lang.internal.el.ExpressionContext;
 import org.reaktivity.specification.mqtt.internal.types.MqttCapabilities;
-import org.reaktivity.specification.mqtt.internal.types.MqttUserPropertyFW;
 import org.reaktivity.specification.mqtt.internal.types.control.MqttRouteExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttAbortExFW;
 import org.reaktivity.specification.mqtt.internal.types.stream.MqttBeginExFW;
@@ -56,22 +55,6 @@ public class MqttFunctionsTest
     {
         MqttFunctions.Mapper mapper = new MqttFunctions.Mapper();
         assertEquals("mqtt", mapper.getPrefixName());
-    }
-
-    @Test
-    public void shouldEncodeUserProperty()
-    {
-        final byte[] bytes = MqttFunctions.userProperty("name", "value");
-
-        DirectBuffer buffer = new UnsafeBuffer(bytes);
-        MqttUserPropertyFW userProperty = new MqttUserPropertyFW().wrap(buffer, 0, buffer.capacity());
-
-        MqttUserPropertyFW expected = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
-                                                                      .key("name")
-                                                                      .value("value")
-                                                                      .build();
-        assertEquals(expected.key(), userProperty.key());
-        assertEquals(expected.value(), userProperty.value());
     }
 
     @Test

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -213,6 +213,24 @@ public class MqttFunctionsTest
     }
 
     @Test
+    public void shouldEncodeMqttDataExWithUserPropertyNoTopic()
+    {
+        final byte[] array = MqttFunctions.dataEx()
+                                          .typeId(0)
+                                          .userProperty("name", "value")
+                                          .build();
+
+        DirectBuffer buffer = new UnsafeBuffer(array);
+        MqttDataExFW mqttDataEx = new MqttDataExFW().wrap(buffer, 0, buffer.capacity());
+
+        assertEquals(0, mqttDataEx.typeId());
+        assertNotNull(mqttDataEx.properties()
+                                .matchFirst(h ->
+                                                "name".equals(h.key().asString()) &&
+                                                    "value".equals(h.value().asString())) != null);
+    }
+
+    @Test
     public void shouldEncodeMqttDataExWithUserProperties()
     {
         final byte[] array = MqttFunctions.dataEx()

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -66,7 +66,12 @@ public class MqttFunctionsTest
         DirectBuffer buffer = new UnsafeBuffer(bytes);
         MqttUserPropertyFW userProperty = new MqttUserPropertyFW().wrap(buffer, 0, buffer.capacity());
 
-        assertArrayEquals(userProperty.buffer().byteArray(), bytes);
+        MqttUserPropertyFW expected = new MqttUserPropertyFW.Builder().wrap(new UnsafeBuffer(new byte[1024]),0, 1024)
+                                                                      .key("name")
+                                                                      .value("value")
+                                                                      .build();
+        assertEquals(expected.key(), userProperty.key());
+        assertEquals(expected.value(), userProperty.value());
     }
 
     @Test

--- a/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/internal/MqttFunctionsTest.java
@@ -314,6 +314,33 @@ public class MqttFunctionsTest
     }
 
     @Test
+    public void shouldEncodeMqttDataExWithNullDefaults()
+    {
+        final byte[] array = MqttFunctions.dataEx()
+                                          .typeId(0)
+                                          .expiryInterval(15)
+                                          .format("TEXT")
+                                          .correlation("request-id-1")
+                                          .userProperty("name", "value")
+                                          .build();
+
+        DirectBuffer buffer = new UnsafeBuffer(array);
+        MqttDataExFW mqttDataEx = new MqttDataExFW().wrap(buffer, 0, buffer.capacity());
+
+        assertEquals(0, mqttDataEx.typeId());
+        assertNull(mqttDataEx.topic().asString());
+        assertEquals(15, mqttDataEx.expiryInterval());
+        assertNull(mqttDataEx.contentType().asString());
+        assertEquals("TEXT", mqttDataEx.format().toString());
+        assertNull(mqttDataEx.responseTopic().asString());
+        assertEquals("MQTT_BINARY [length=12, bytes=octets[12]]",  mqttDataEx.correlation().toString());
+        assertNotNull(mqttDataEx.properties()
+                                .matchFirst(h ->
+                                                "name".equals(h.key().asString()) &&
+                                                    "value".equals(h.value().asString())) != null);
+    }
+
+    @Test
     public void shouldEncodeMqttDataExWithBytes()
     {
         final byte[] array = MqttFunctions.dataEx()

--- a/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
@@ -155,4 +155,28 @@ public class ConnectionIT
         k3po.notifyBarrier("ROUTED_SERVER");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${scripts}/disconnect.after.keep.alive.timeout/client",
+        "${scripts}/disconnect.after.keep.alive.timeout/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldDisconnectClientAfterKeepAliveTimeout() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/keep.alive.with.pingreq/client",
+        "${scripts}/keep.alive.with.pingreq/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldKeepAliveWithPingreq() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
`string8`, `string16`, and `string32` can now specify default values in the .idl (both string literals and null are valid)