### PR TITLE
Update capabilities when PUBLISH comes after SUBSCRIBE

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/client.rpt
@@ -1,0 +1,55 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_SERVER
+        "nukleus://streams/mqtt#0"
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+connected
+
+write [0x10 0x13]                   # CONNECT header
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x02]                        # connect flags = clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x00]                        # properties = none
+      [0x00 0x06] "client"          # clientId
+
+read  [0x20 0x03]                   # CONNACK header
+      [0x00]                        # connect flags = none
+      [0x00]                        # reason code
+      [0x00]                        # properties = none
+
+write [0x82 0x12]                   # SUBSCRIBE header
+      [0x00 0x01]                   # packetId = 1
+      [0x02]                        # properties
+      [0x0b 0x01]                   # subscriptionId = 1
+      [0x00 0x0a] "sensor/one"      # topic filter
+      [0x00]                        # subscription opts = QoS 0
+
+read  [0x90 0x04]                   # SUBACK header
+      [0x00 0x01]                   # packetId = 1
+      [0x00]                        # properties = none
+      [0x00]                        # reason code
+
+write [0x30 0x24]                   # PUBLISH header
+      [0x00 0x0a] "sensor/one"      # topic name
+      [0x10]                        # properties
+      [0x02] 0x0f                   # 15 second expiry interval
+      [0x03 0x07] "message"         # content type
+      [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
+      "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/server.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+accepted
+connected
+
+read  [0x10 0x13]                   # CONNECT header
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x02]                        # connect flags = clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x00]                        # properties = none
+      [0x00 0x06] "client"          # clientId
+
+write [0x20 0x03]                   # CONNACK header
+      [0x00]                        # connect flags = none
+      [0x00]                        # reason code
+      [0x00]                        # properties = none
+
+read  [0x82 0x12]                   # SUBSCRIBE header
+      [0x00 0x01]                   # packetId = 1
+      [0x02]                        # properties
+      [0x0b 0x01]                   # subscriptionId = 1
+      [0x00 0x0a] "sensor/one"      # topic filter
+      [0x00]                        # subscription opts = QoS 0
+
+write [0x90 0x04]                   # SUBACK header
+      [0x00 0x01]                   # packetId = 1
+      [0x00]                        # properties = none
+      [0x00]                        # reason code
+
+read  [0x30 0x24]                   # PUBLISH header
+      [0x00 0x0a] "sensor/one"      # topic name
+      [0x10]                        # properties
+      [0x02] 0x0f                   # 15 second expiry interval
+      [0x03 0x07] "message"         # content type
+      [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
+      "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/client.rpt
@@ -28,7 +28,6 @@ write nukleus:begin.ext ${mqtt:beginEx()
                               .build()}
 connected
 
-write flush
 write nukleus:data.ext ${mqtt:dataEx()
                              .typeId(nukleus:id("mqtt"))
                              .topic("sensor/one")
@@ -38,3 +37,4 @@ write nukleus:data.ext ${mqtt:dataEx()
                              .build()}
 
 write "message"
+write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_CLIENT
+        "nukleus://streams/mqtt#0"
+         option nukleus:window 8192
+         option nukleus:transmission "duplex"
+
+write nukleus:begin.ext ${mqtt:beginEx()
+                              .typeId(nukleus:id("mqtt"))
+                              .capabilities("SUBSCRIBE_ONLY")
+                              .clientId("client")
+                              .topic("sensor/one")
+                              .subscriptionId(1)
+                              .build()}
+connected
+
+write flush
+write nukleus:data.ext ${mqtt:dataEx()
+                             .typeId(nukleus:id("mqtt"))
+                             .topic("sensor/one")
+                             .expiryInterval(15)
+                             .contentType("message")
+                             .format("TEXT")
+                             .build()}
+
+write "message"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/mqtt/streams/subscribe.one.message.then.publish.message/server.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+        option nukleus:window 8192
+        option nukleus:transmission "duplex"
+
+accepted
+
+read nukleus:begin.ext ${mqtt:beginEx()
+                             .typeId(nukleus:id("mqtt"))
+                             .capabilities("SUBSCRIBE_ONLY")
+                             .clientId("client")
+                             .topic("sensor/one")
+                             .subscriptionId(1)
+                             .build()}
+connected
+
+read nukleus:data.ext ${mqtt:dataEx()
+                            .typeId(nukleus:id("mqtt"))
+                            .topic("sensor/one")
+                            .expiryInterval(15)
+                            .contentType("message")
+                            .format("TEXT")
+                            .build()}
+
+read "message"

--- a/src/test/java/org/reaktivity/specification/mqtt/streams/PublishIT.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/streams/PublishIT.java
@@ -100,6 +100,18 @@ public class PublishIT
 
     @Test
     @Specification({
+        "${scripts}/subscribe.one.message.then.publish.message/client",
+        "${scripts}/subscribe.one.message.then.publish.message/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldSubscriberOneMessageThenPublishMessage() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/publish.message.and.subscribe.correlated.message/client",
         "${scripts}/publish.message.and.subscribe.correlated.message/server"})
     @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")

--- a/src/test/java/org/reaktivity/specification/nukleus/mqtt/streams/StreamIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/mqtt/streams/StreamIT.java
@@ -183,6 +183,18 @@ public class StreamIT
 
     @Test
     @Specification({
+        "${scripts}/subscribe.one.message.then.publish.message/client",
+        "${scripts}/subscribe.one.message.then.publish.message/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldSubscriberOneMessageThenPublishMessage() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/publish.message.and.subscribe.correlated.message/client",
         "${scripts}/publish.message.and.subscribe.correlated.message/server"})
     @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")


### PR DESCRIPTION
Allows streams to update their capabilities from `SUBSCRIBE_ONLY` to `PUBLISH_ONLY` or `PUBLISH_AND_SUBSCRIBE` when client sends `PUBLISH` some time after sending `SUBSCRIBE` for the same topic.