### PR TITLE
Support server assigned client identifier

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/reject.missing.client.id/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/reject.missing.client.id/client.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_SERVER
+        "nukleus://streams/mqtt#0"
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+connected
+
+write [0x10 0x0b]                   # CONNECT header
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x02]                        # connect flags = clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x00]                        # properties = none
+
+read  [0x20 0x03]                   # CONNACK header
+      [0x00]                        # connect flags = none
+      [0x82]                        # reason code = protocol error
+      [0x00]                        # properties = none
+
+read closed

--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/reject.missing.client.id/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/reject.missing.client.id/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+accepted
+connected
+
+read   [0x10 0x0b]                   # CONNECT header
+       [0x00 0x04] "MQTT"            # protocol name
+       [0x05]                        # protocol version
+       [0x02]                        # connect flags = clean start
+       [0x00 0x3c]                   # keep alive = 60s
+       [0x00]                        # properties = none
+
+write  [0x20 0x03]                   # CONNACK header
+       [0x00]                        # connect flags = none
+       [0x82]                        # reason code = protocol error
+       [0x00]                        # properties = none
+
+write close

--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/client.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect await ROUTED_SERVER
+        "nukleus://streams/mqtt#0"
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+connected
+
+write [0x10 0x0d]             # CONNECT header
+      [0x00 0x04] "MQTT"      # protocol name
+      [0x05]                  # protocol version
+      [0x02]                  # connect flags = clean start
+      [0x00 0x3c]             # keep alive = 60s
+      [0x00]                  # properties = none
+      [0x00 0x00]             # clientId
+
+read  [0x20 0x0b]             # CONNACK header
+      [0x00]                  # connect flags = none
+      [0x00]                  # reason code
+      [0x08]                  # properties
+      [0x12 0x06] "client"    # assigned clientId

--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2016-2020 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverTransport "nukleus://streams/target#0"
+
+accept ${serverTransport}
+  option nukleus:window 8192
+  option nukleus:transmission "duplex"
+
+accepted
+connected
+
+read  [0x10 0x0d]             # CONNECT header
+      [0x00 0x04] "MQTT"      # protocol name
+      [0x05]                  # protocol version
+      [0x02]                  # connect flags = clean start
+      [0x00 0x3c]             # keep alive = 60s
+      [0x00]                  # properties = none
+      [0x00 0x00]             # clientId
+
+write [0x20 0x0b]             # CONNACK header
+      [0x00]                  # connect flags = none
+      [0x00]                  # reason code
+      [0x08]                  # properties
+      [0x12 0x06] "client"    # assigned clientId

--- a/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
@@ -62,6 +62,18 @@ public class ConnectionIT
 
     @Test
     @Specification({
+        "${scripts}/connect/reject.missing.client.id/client",
+        "${scripts}/connect/reject.missing.client.id/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldRejectMissingClientId() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/disconnect/client",
         "${scripts}/disconnect/server"})
     @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")

--- a/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/specification/mqtt/streams/ConnectionIT.java
@@ -50,6 +50,18 @@ public class ConnectionIT
 
     @Test
     @Specification({
+        "${scripts}/connect/server.assigned.client.id/client",
+        "${scripts}/connect/server.assigned.client.id/server"})
+    @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")
+    public void shouldConnectWithServerAssignedClientId() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${scripts}/disconnect/client",
         "${scripts}/disconnect/server"})
     @ScriptProperty("serverTransport \"nukleus://streams/mqtt#0\"")


### PR DESCRIPTION
Upon receiving an zero length client identifier on `CONNECT`, server must assign a unique client identifier to the client via `CONNACK`.