### PR TITLE
Update Mqtt Properties to Correct UTF-8 Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
     <jacoco.missed.count>0</jacoco.missed.count>
     <junit.version>4.12</junit.version>
 
-    <k3po.version>3.0.0-alpha-104</k3po.version>
-    <reaktor.version>0.136</reaktor.version>
+    <k3po.version>3.0.0-alpha-106</k3po.version>
+    <reaktor.version>0.139</reaktor.version>
 
-    <nukleus.plugin.version>0.53</nukleus.plugin.version>
+    <nukleus.plugin.version>0.61</nukleus.plugin.version>
     <nukleus.spec.version>0.48</nukleus.spec.version>
   </properties>
 

--- a/src/main/resources/META-INF/reaktivity/mqtt.idl
+++ b/src/main/resources/META-INF/reaktivity/mqtt.idl
@@ -54,7 +54,7 @@ scope mqtt
         struct MqttBeginEx extends core::stream::Extension
         {
             MqttCapabilities capabilities = PUBLISH_AND_SUBSCRIBE;
-            string8 clientId;
+            string16 clientId;
             string16 topic;
             varbyteuint32 subscriptionId = 0;
             MqttUserProperty[] properties;
@@ -65,9 +65,9 @@ scope mqtt
             int32 deferred = 0;             // INIT only (TODO: move to DATA frame)
             string16 topic = null;
             int32 expiryInterval = -1;
-            string8 contentType = null;
+            string16 contentType = null;
             MqttPayloadFormat format = BINARY;
-            string8 responseTopic = null;
+            string16 responseTopic = null;
             MqttBinary correlation;
             MqttUserProperty[] properties;
         }

--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/client.rpt
@@ -29,8 +29,8 @@ write [0x10 0x0d]             # CONNECT header
       [0x00]                  # properties = none
       [0x00 0x00]             # clientId
 
-read  [0x20 0x0b]             # CONNACK header
+read  [0x20 0x0c]             # CONNACK header
       [0x00]                  # connect flags = none
       [0x00]                  # reason code
-      [0x08]                  # properties
-      [0x12 0x06] "client"    # assigned clientId
+      [0x09]                  # properties
+      [0x12 0x00 0x06] "client"    # assigned clientId

--- a/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/connect/server.assigned.client.id/server.rpt
@@ -31,8 +31,8 @@ read  [0x10 0x0d]             # CONNECT header
       [0x00]                  # properties = none
       [0x00 0x00]             # clientId
 
-write [0x20 0x0b]             # CONNACK header
+write [0x20 0x0c]             # CONNACK header
       [0x00]                  # connect flags = none
       [0x00]                  # reason code
-      [0x08]                  # properties
-      [0x12 0x06] "client"    # assigned clientId
+      [0x09]                  # properties
+      [0x12 0x00 0x06] "client"    # assigned clientId

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.message.and.subscribe.correlated.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.message.and.subscribe.correlated.message/client.rpt
@@ -46,13 +46,13 @@ read  [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-read  [0x30 0x39]                   # PUBLISH header
+read  [0x30 0x3b]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x25]                        # properties
+      [0x27]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"      # response topic
+      [0x08 0x00 0x0a] "sensor/one" # response topic
       [0x09 0x00 0x04] "info"       # correlation data
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.message.and.subscribe.correlated.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.message.and.subscribe.correlated.message/server.rpt
@@ -48,13 +48,13 @@ write [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-write [0x30 0x39]                   # PUBLISH header
+write [0x30 0x3b]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x25]                        # properties
+      [0x27]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"      # response topic
+      [0x08 0x00 0x0a] "sensor/one" # response topic
       [0x09 0x00 0x04] "info"       # correlation data
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages.with.delay/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages.with.delay/client.rpt
@@ -34,36 +34,36 @@ read  [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message1"                     # payload
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message2"                     # payload
 
 write notify PUBLISHED_MESSAGE_TWO
 write await PUBLISH_MESSAGE_THREE
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message3"                     # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages.with.delay/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages.with.delay/server.rpt
@@ -36,33 +36,33 @@ write [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message1"                     # payload
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message2"                     # payload
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message3"                     # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages/client.rpt
@@ -34,32 +34,32 @@ read  [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message1"                     # payload
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message2"                     # payload
 
-write [0x30 0x38]                    # PUBLISH header
+write [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message3"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.multiple.messages/server.rpt
@@ -36,33 +36,33 @@ write [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message1"                     # payload
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message2"                     # payload
 
-read  [0x30 0x38]                    # PUBLISH header
+read  [0x30 0x3a]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message3"                     # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message.with.packetId/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message.with.packetId/client.rpt
@@ -34,14 +34,14 @@ read  [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-write [0x30 0x39]                    # PUBLISH header
+write [0x30 0x3b]                    # PUBLISH header
       [0x00 0x01]                    # packetId = 1
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message.with.packetId/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message.with.packetId/server.rpt
@@ -36,14 +36,14 @@ write [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-read  [0x30 0x39]                    # PUBLISH header
+read  [0x30 0x3b]                    # PUBLISH header
       [0x00 0x01]                    # packetId = 1
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message/client.rpt
@@ -34,13 +34,13 @@ read  [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-write [0x30 0x37]                    # PUBLISH header
+write [0x30 0x39]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/publish.one.message/server.rpt
@@ -36,13 +36,13 @@ write [0x20 0x03]                    # CONNACK header
       [0x00]                         # reason code
       [0x00]                         # properties = none
 
-read  [0x30 0x37]                    # PUBLISH header
+read  [0x30 0x39]                    # PUBLISH header
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/reject.publish.one.message.with.packet.id/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/reject.publish.one.message.with.packet.id/client.rpt
@@ -45,14 +45,14 @@ read  [0x90 0x02]                    # SUBACK header
       [0x00]                         # property length
       [0x00]                         # reason code
 
-read  [0x30 0x39]                    # PUBLISH header
+read  [0x30 0x3b]                    # PUBLISH header
       [0x00 0x01]                    # packetId = 1
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/reject.publish.one.message.with.packet.id/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/reject.publish.one.message.with.packet.id/server.rpt
@@ -47,14 +47,14 @@ write [0x90 0x02]                    # SUBACK header
       [0x00]                         # property length
       [0x00]                         # reason code
 
-write [0x30 0x39]                    # PUBLISH header
+write [0x30 0x3b]                    # PUBLISH header
       [0x00 0x01]                    # packetId = 1
       [0x00 0x0a] "sensor/one"       # topic name
-      [0x23]                         # properties
+      [0x25]                         # properties
       [0x02] 0x0f                    # 15 second expiry interval
-      [0x03 0x07] "message"          # content type
+      [0x03 0x00 0x07] "message"     # content type
       [0x01 0x01]                    # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
-      [0x08 0x0a] "sensor/one"       # response topic
+      [0x08 0x00 0x0a] "sensor/one"  # response topic
       [0x09 0x00 0x04] "info"        # correlation data
       "message"                      # payload
 

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.fails.then.publish.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.fails.then.publish.message/client.rpt
@@ -46,10 +46,10 @@ read  [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x8f]                        # topic filter invalid
 
-write [0x30 0x24]                   # PUBLISH header
+write [0x30 0x25]                   # PUBLISH header
       [0x00 0x0a] "/control/1"      # topic name
-      [0x10]                        # properties
+      [0x11]                        # properties
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.fails.then.publish.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.fails.then.publish.message/server.rpt
@@ -48,10 +48,10 @@ write [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x8f]                        # topic filter invalid
 
-read  [0x30 0x24]                   # PUBLISH header
+read  [0x30 0x25]                   # PUBLISH header
       [0x00 0x0a] "/control/1"      # topic name
-      [0x10]                        # properties
+      [0x11]                        # properties
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/client.rpt
@@ -46,10 +46,10 @@ read  [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-write [0x30 0x24]                   # PUBLISH header
+write [0x30 0x25]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x10]                        # properties
+      [0x11]                        # properties
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.then.publish.message/server.rpt
@@ -48,10 +48,10 @@ write [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-read  [0x30 0x24]                   # PUBLISH header
+read  [0x30 0x25]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x10]                        # properties
+      [0x11]                        # properties
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.with.pattern.topic/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.with.pattern.topic/client.rpt
@@ -46,11 +46,11 @@ read  [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-read  [0x30 0x26]                   # PUBLISH header
+read  [0x30 0x27]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x12]                        # properties
+      [0x13]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.with.pattern.topic/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message.with.pattern.topic/server.rpt
@@ -48,11 +48,11 @@ write [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-write [0x30 0x26]                   # PUBLISH header
+write [0x30 0x27]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x12]                        # properties
+      [0x13]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message/client.rpt
@@ -46,11 +46,11 @@ read  [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-read  [0x30 0x26]                   # PUBLISH header
+read  [0x30 0x27]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x12]                        # properties
+      [0x13]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload

--- a/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/mqtt/subscribe.one.message/server.rpt
@@ -48,11 +48,11 @@ write [0x90 0x04]                   # SUBACK header
       [0x00]                        # properties = none
       [0x00]                        # reason code
 
-write [0x30 0x26]                   # PUBLISH header
+write [0x30 0x27]                   # PUBLISH header
       [0x00 0x0a] "sensor/one"      # topic name
-      [0x12]                        # properties
+      [0x13]                        # properties
       [0x0b 0x01]                   # subscription id = 1
       [0x02] 0x0f                   # 15 second expiry interval
-      [0x03 0x07] "message"         # content type
+      [0x03 0x00 0x07] "message"    # content type
       [0x01 0x01]                   # payload format indicator: 0 = unspecified bytes, 1 = UTF-8 TEXT
       "message"                     # payload


### PR DESCRIPTION
updated all applicable string8 properties to string 16. All raw protocol scripts updated to accommodate for the correct 2 length bytes, according to [mqtt specification.](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_UTF-8_Encoded_String)